### PR TITLE
Fixing typo and french translation for installation manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -47,7 +47,7 @@
                 "name": "registration",
                 "type": "boolean",
                 "ask": {
-                    "en": "Is the registraion open for new users?"
+                    "en": "Is the registration open for new users?"
                 },
                 "default": false
             },

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,8 @@
     "id": "pleroma",
     "packaging_format": 1,
     "description": {
-        "en": "Pleroma is an OStatus-compatible social networking server written in Elixir, compatible with GNU Social and Mastodon"
+        "en": "Pleroma is an OStatus-compatible social networking server written in Elixir, compatible with GNU Social and Mastodon",
+        "fr": "Pleroma est un réseau social écrit en Elixir, compatible avec OStatus, GNU Social et Mastodon"
     },
     "version": "0.9.0",
     "url": "https://git.pleroma.social/pleroma/pleroma",
@@ -25,7 +26,8 @@
                 "name": "domain",
                 "type": "domain",
                 "ask": {
-                    "en": "Choose a domain name for pleroma"
+                    "en": "Choose a domain name for pleroma",
+                    "fr": "Choisissez un nom de domaine pour pleroma"
                 },
                 "example": "example.com"
             },
@@ -40,14 +42,16 @@
             {
                 "name": "name",
                 "ask": {
-                    "en": "Choose a name for your Pleroma instance"
+                    "en": "Choose a name for your Pleroma instance",
+                    "fr": "Choisissez un nom pour votre instance Pleroma"
                 }
             },
             {
                 "name": "registration",
                 "type": "boolean",
                 "ask": {
-                    "en": "Is the registration open for new users?"
+                    "en": "Is the registration open for new users?",
+                    "fr": "Est-ce que l'inscription est ouverte aux nouveaux utilisateurs ?"
                 },
                 "default": false
             },
@@ -55,14 +59,16 @@
                 "name": "cache",
                 "type": "boolean",
                 "ask": {
-                    "en": "Enable media-cache for your instance"
+                    "en": "Enable media-cache for your instance",
+                    "fr": "Activer le cache média pour votre instance"
                 },
                 "default": true
                },
             {
                 "name": "size",
                 "ask": {
-                    "en": "Select the cache size. If you did not enabled media-cache in above option then this option will have no effect"
+                    "en": "Select the cache size. If you did not enabled media-cache in above option then this option will have no effect",
+                    "fr": "Sélectionner la taille du cache. Si vous n'avez pas activé le cache média ci-dessus, cette option n'aura aucun effet"
                 },
                 "choices": ["2g","5g","10g","20g","40g","80g"],
                 "default": "5g"
@@ -71,7 +77,8 @@
                 "name": "is_public",
                 "type": "boolean",
                 "ask": {
-                    "en": "Is it a public application?"
+                    "en": "Is it a public application?",
+                    "fr": "Est-ce une application publique ?"
                 },
                 "default": true
             }


### PR DESCRIPTION
While installing pleroma on my YNH instance, I noticed a typo: "registraion"
I went ahead and fixed it, and while I was at it, I added french translation for the installation manifest.