### PR TITLE
Solving 3 issues during Pleroma installation

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -117,6 +117,8 @@ ynh_app_setting_set "$app" psqlpwd "$db_pwd"
 ynh_psql_test_if_first_run
 ynh_psql_create_user "$app" "$db_pwd"
 ynh_psql_execute_as_root \
+"ALTER USER $app WITH SUPERUSER;"
+ynh_psql_execute_as_root \
 "CREATE DATABASE $db_name ENCODING 'UTF8' LC_COLLATE='C' LC_CTYPE='C' template=template0 OWNER $app;"
 ynh_psql_execute_as_root "\connect $db_name 
 CREATE EXTENSION IF NOT EXISTS unaccent;CREATE EXTENSION IF NOT EXISTS pg_trgm;"

--- a/scripts/install
+++ b/scripts/install
@@ -207,8 +207,7 @@ chown -R "$app":"$app" "$final_path"
 # Make user admin
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user set "$admin" --admin )
 # Retrieve a password reset link that you can then send to the user
-( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user reset_password "$admin" )
-admin_pass_reset_url=$(!!)
+admin_pass_reset_url=$( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user reset_password "$admin" )
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/install
+++ b/scripts/install
@@ -207,7 +207,7 @@ chown -R "$app":"$app" "$final_path"
 # Make user admin
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user set "$admin" --admin )
 # Retrieve a password reset link that you can then send to the user
-admin_pass_reset_url=$( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user reset_password "$admin" )
+admin_pass_reset_url=$( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user reset_password "$admin" | tail -1 )
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/install
+++ b/scripts/install
@@ -201,7 +201,7 @@ chown -R "$app":"$app" "$final_path"
 ( cd $final_path/$app && sudo -u "$app" mix deps.get )
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix ecto.migrate --force )
 # Add user
-( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix plemora.user "$admin_name" "$admin_email" "$admin_pass" )
+( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user "$admin_name" "$admin_email" "$admin_pass" )
 # Make user moderator
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix set_moderator "$admin" true )
 

--- a/scripts/install
+++ b/scripts/install
@@ -200,14 +200,12 @@ chown -R "$app":"$app" "$final_path"
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix local.rebar --force )
 ( cd $final_path/$app && sudo -u "$app" mix deps.get )
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix ecto.migrate --force )
-# Add user
-( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user new "$admin" "$admin_email" )
+# Add user and retrieve a password reset link that you can then send to the user
+admin_pass_reset_url=$( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user new "$admin" "$admin_email" | tail -1 )
 # Make user moderator
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user set "$admin" --moderator )
 # Make user admin
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user set "$admin" --admin )
-# Retrieve a password reset link that you can then send to the user
-admin_pass_reset_url=$( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user reset_password "$admin" | tail -1 )
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/install
+++ b/scripts/install
@@ -201,7 +201,7 @@ chown -R "$app":"$app" "$final_path"
 ( cd $final_path/$app && sudo -u "$app" mix deps.get )
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix ecto.migrate --force )
 # Add user
-( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix register_user "$admin" "$admin_name" "$admin_email" "Moderator of this instance" "$admin_pass" )
+( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix plemora.user "$admin_name" "$admin_email" "$admin_pass" )
 # Make user moderator
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix set_moderator "$admin" true )
 

--- a/scripts/install
+++ b/scripts/install
@@ -201,11 +201,13 @@ chown -R "$app":"$app" "$final_path"
 ( cd $final_path/$app && sudo -u "$app" mix deps.get )
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix ecto.migrate --force )
 # Add user
-( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user new "$admin" "$admin_email" "$admin_pass" )
+( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user new "$admin" "$admin_email" )
 # Make user moderator
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user set "$admin" --moderator )
 # Make user admin
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user set "$admin" --admin )
+# Send reset password mail
+( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user reset_password "$admin" )
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/install
+++ b/scripts/install
@@ -208,7 +208,7 @@ chown -R "$app":"$app" "$final_path"
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user set "$admin" --admin )
 # Retrieve a password reset link that you can then send to the user
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user reset_password "$admin" )
-admin_pass_reset_url = $(!!)
+admin_pass_reset_url=$(!!)
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/install
+++ b/scripts/install
@@ -207,7 +207,7 @@ chown -R "$app":"$app" "$final_path"
 # Make user admin
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user set "$admin" --admin )
 # Retrieve a password reset link that you can then send to the user
-admin_pass_reset_url=( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user reset_password "$admin" )
+( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user reset_password "$admin" ) > admin_pass_reset_url
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/install
+++ b/scripts/install
@@ -26,7 +26,7 @@ path_url="/"
 admin=$YNH_APP_ARG_ADMIN
 admin_email=$(ynh_user_get_info $admin 'mail')
 admin_name=$(ynh_user_get_info $admin 'firstname')
-admin_pass=$(ynh_string_random 24)
+admin_pass_reset_url=""
 is_public=$YNH_APP_ARG_IS_PUBLIC
 random_key=$(ynh_random 64)
 name=$YNH_APP_ARG_NAME
@@ -206,8 +206,8 @@ chown -R "$app":"$app" "$final_path"
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user set "$admin" --moderator )
 # Make user admin
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user set "$admin" --admin )
-# Send reset password mail
-( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user reset_password "$admin" )
+# Retrieve a password reset link that you can then send to the user
+admin_pass_reset_url=( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user reset_password "$admin" )
 
 #=================================================
 # SETUP SSOWAT
@@ -246,7 +246,7 @@ message=" $app was successfully installed :)
 Please open your $app domain: https://$domain$path_url
 
 The moderator username is: $admin
-The moderator password is: $admin_pass
+To reset your password: $admin_pass_reset_url
 
 If you are facing any problem or want to improve this app, please open a new issue here: https://github.com/YunoHost-Apps/pleroma_ynh/
 If you are not afraid of the terminal, check out https://git.pleroma.social/pleroma/pleroma/wikis/home to see what more you can do with your awesome instance!"

--- a/scripts/install
+++ b/scripts/install
@@ -207,7 +207,8 @@ chown -R "$app":"$app" "$final_path"
 # Make user admin
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user set "$admin" --admin )
 # Retrieve a password reset link that you can then send to the user
-( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user reset_password "$admin" ) > admin_pass_reset_url
+( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user reset_password "$admin" )
+admin_pass_reset_url = $(!!)
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/install
+++ b/scripts/install
@@ -201,9 +201,11 @@ chown -R "$app":"$app" "$final_path"
 ( cd $final_path/$app && sudo -u "$app" mix deps.get )
 ( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix ecto.migrate --force )
 # Add user
-( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user "$admin_name" "$admin_email" "$admin_pass" )
+( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user new "$admin" "$admin_email" "$admin_pass" )
 # Make user moderator
-( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix set_moderator "$admin" true )
+( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user set "$admin" --moderator )
+# Make user admin
+( cd $final_path/$app && sudo -u "$app" MIX_ENV=prod mix pleroma.user set "$admin" --admin )
 
 #=================================================
 # SETUP SSOWAT


### PR DESCRIPTION
1- During mix ecto.migrate at L200 => ** (Postgrex.Error) ERROR 42501 (insufficient_privilege): permission denied to create extension "uuid-ossp" => solved L120 Granting Plemora User SUPERUSER right
2- L202, error ** (Mix) The task "register_user" could not be found => there is a change in the plemora user creation syntax
3- In the new plemora user creation syntax, we cannot provide a password. we can only retrieve a password reset link => change made to retrieve this link and provide it in the mail to the user
4- L204 => there is a change in the make user moderator syntax