### PR TITLE
Fix registration choice not taken into account

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A free, federated social networking server built on open protocols.",
         "fr": "Un serveur de réseautage social fédéré et gratuit basé sur des protocoles ouverts."
     },
-    "version": "2.4.4~ynh1",
+    "version": "2.4.4~ynh2",
     "url": "https://pleroma.social/",
     "upstream": {
         "license": "AGPL-3.0-only",

--- a/scripts/install
+++ b/scripts/install
@@ -209,6 +209,8 @@ popd
 cat "../conf/ldap.exs" >> "$config"
 
 ynh_replace_string --match_string="config :pleroma, configurable_from_database: false" --replace_string="config :pleroma, configurable_from_database: true" --target_file="$config"
+registration_bool_value=`(($registration)) && echo "true" || echo "false"`
+ynh_replace_string --match_string="registrations_open: true" --replace_string="registrations_open: $registration_bool_value" --target_file="$config"
 
 pushd $final_path/live
 	ynh_exec_warn_less ynh_exec_as $app -s $SHELL -lc "$final_path/live/bin/pleroma_ctl migrate"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -150,6 +150,7 @@ ynh_system_user_create --username=$app --home_dir="$final_path"
 # UPGRADE TO OTP RELEASE
 #=================================================
 
+config="/etc/$app/config.exs"
 if ynh_version_gt "1.1.1~ynh1" "${previous_version}" ; then
 	ynh_script_progression --message="Upgrading to OTP release..." --weight=1
 
@@ -175,7 +176,6 @@ if ynh_version_gt "1.1.1~ynh1" "${previous_version}" ; then
 
 	mkdir -p /etc/$app
 	chown -R $app /etc/$app
-	config="/etc/$app/config.exs"
 	mv $final_path/live/config/prod.secret.exs $config
 	ynh_replace_string --match_string="use Mix.Config" --replace_string="import Config" --target_file="$config"
 	echo "config :pleroma, :instance, static_dir: \"/home/yunohost.app/$app/static\"" >> $config
@@ -187,9 +187,13 @@ if ynh_version_gt "1.1.1~ynh1" "${previous_version}" ; then
 fi
 
 if ynh_version_gt "2.0.5~ynh1" "${previous_version}" ; then
-	config="/etc/$app/config.exs"
 	cat "../conf/ldap.exs" >> "$config"
 	ynh_replace_string --match_string="config :pleroma, configurable_from_database: false" --replace_string="config :pleroma, configurable_from_database: true" --target_file="$config"
+fi
+
+if ynh_version_gt "2.4.4~ynh2" "${previous_version}"; then
+	registration_bool_value=`(($registration)) && echo "true" || echo "false"`
+	ynh_replace_string --match_string='registrations_open: true' --replace_string="registrations_open: $registration_bool_value" --target_file="$config"
 fi
 
 #=================================================


### PR DESCRIPTION
## Problem

- When you ask for not opening the registration, the visitor still can create accounts. The choice is not taken into account.

## Solution

- Replace the value for the `registrations_open` key in the installation and change it on the upgrade from versions below `2.4.4~ynh2`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
