### PR TITLE
Upgrade to version 2.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post
 **Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
 
 
-**Shipped version:** 2.5.0~ynh1
+**Shipped version:** 2.5.1~ynh1
 
 **Demo:** http://distsn.org/pleroma-instances.html
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It shall NOT be edited by hand.
 
 # Pleroma for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/pleroma.svg)](https://dash.yunohost.org/appci/app/pleroma) ![Working status](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)  
+[![Integration level](https://dash.yunohost.org/integration/pleroma.svg)](https://dash.yunohost.org/appci/app/pleroma) ![Working status](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)
 [![Install Pleroma with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=pleroma)
 
 *[Lire ce readme en français.](./README_fr.md)*
@@ -22,7 +22,7 @@ For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post
 **Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
 
 
-**Shipped version:** 2.4.5~ynh2
+**Shipped version:** 2.5.0~ynh1
 
 **Demo:** http://distsn.org/pleroma-instances.html
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ It shall NOT be edited by hand.
 # Pleroma for YunoHost
 
 [![Integration level](https://dash.yunohost.org/integration/pleroma.svg)](https://dash.yunohost.org/appci/app/pleroma) ![Working status](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)
+
 [![Install Pleroma with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=pleroma)
 
 *[Lire ce readme en français.](./README_fr.md)*

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,7 +5,7 @@ It shall NOT be edited by hand.
 
 # Pleroma pour YunoHost
 
-[![Niveau d’intégration](https://dash.yunohost.org/integration/pleroma.svg)](https://dash.yunohost.org/appci/app/pleroma) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)  
+[![Niveau d’intégration](https://dash.yunohost.org/integration/pleroma.svg)](https://dash.yunohost.org/appci/app/pleroma) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)
 [![Installer Pleroma avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=pleroma)
 
 *[Read this readme in english.](./README.md)*
@@ -22,7 +22,7 @@ For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post
 **Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
 
 
-**Version incluse :** 2.4.5~ynh2
+**Version incluse :** 2.5.0~ynh1
 
 **Démo :** http://distsn.org/pleroma-instances.html
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -6,6 +6,7 @@ It shall NOT be edited by hand.
 # Pleroma pour YunoHost
 
 [![Niveau d’intégration](https://dash.yunohost.org/integration/pleroma.svg)](https://dash.yunohost.org/appci/app/pleroma) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)
+
 [![Installer Pleroma avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=pleroma)
 
 *[Read this readme in english.](./README.md)*

--- a/README_fr.md
+++ b/README_fr.md
@@ -23,7 +23,7 @@ For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post
 **Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
 
 
-**Version incluse :** 2.5.0~ynh1
+**Version incluse :** 2.5.1~ynh1
 
 **Démo :** http://distsn.org/pleroma-instances.html
 

--- a/conf/amd64.src
+++ b/conf/amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/226602/artifacts/download?file_type=archive
-SOURCE_SUM=0a8a64ee9642349976ec83be3649d607115b3819a99f7d056135fbe3a5d58480
+SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/230112/artifacts/download?file_type=archive
+SOURCE_SUM=98f9dc5410c96892b356d75a48e2aa937e2e35fce99db44317d445280bc8128c
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/amd64.src
+++ b/conf/amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/224375/artifacts/download?file_type=archive
-SOURCE_SUM=6e2d055795f1f59bbdadf82bfd4ae291e89ac6a65a71091657359cd7eae783d4
+SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/226602/artifacts/download?file_type=archive
+SOURCE_SUM=0a8a64ee9642349976ec83be3649d607115b3819a99f7d056135fbe3a5d58480
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/226606/artifacts/download?file_type=archive
-SOURCE_SUM=9b7092566d2279c0911d86f8641a2a08aef67d5f76563939459e6c1fb1144279
+SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/230116/artifacts/download?file_type=archive
+SOURCE_SUM=05ee20c2a10b8a2393a8aa84fe4f44e86b69fe65321de10cb7a8f6b5c01ac1e4
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/224379/artifacts/download?file_type=archive
-SOURCE_SUM=4c98198401787797681bbc755450a23eb8113420cd4f55f27b980d11378c884e
+SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/226606/artifacts/download?file_type=archive
+SOURCE_SUM=9b7092566d2279c0911d86f8641a2a08aef67d5f76563939459e6c1fb1144279
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/armhf.src
+++ b/conf/armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/224377/artifacts/download?file_type=archive
-SOURCE_SUM=f64d43f86f962fa4a03a2a3108c0cf353ec8f80a5e8b59098470356048a6fdd0
+SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/226604/artifacts/download?file_type=archive
+SOURCE_SUM=90ca77fd63ebe849659864e95af194bb8b7d268f9e5aa13756c4d6a07257a692
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/armhf.src
+++ b/conf/armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/226604/artifacts/download?file_type=archive
-SOURCE_SUM=90ca77fd63ebe849659864e95af194bb8b7d268f9e5aa13756c4d6a07257a692
+SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/230231/artifacts/download?file_type=archive
+SOURCE_SUM=bf7caba3ef502e2b21ec8749606a7b207b7c0a67fb767f33e9826fdfb24852c0
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Federated social networking server built on open protocols",
         "fr": "Serveur de réseautage social fédéré basé sur des protocoles ouverts"
     },
-    "version": "2.5.0~ynh1",
+    "version": "2.5.1~ynh1",
     "url": "https://pleroma.social/",
     "upstream": {
         "license": "AGPL-3.0-only",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Federated social networking server built on open protocols",
         "fr": "Serveur de réseautage social fédéré basé sur des protocoles ouverts"
     },
-    "version": "2.4.5~ynh2",
+    "version": "2.5.0~ynh1",
     "url": "https://pleroma.social/",
     "upstream": {
         "license": "AGPL-3.0-only",

--- a/scripts/install
+++ b/scripts/install
@@ -201,7 +201,8 @@ pushd $final_path/live
 	--static-dir $datadir/static \
 	--listen-ip 127.0.0.1 \
 	--listen-port $port \
-	--strip-uploads Y \
+	--strip-uploads-location Y \
+	--read-uploads-description Y \
 	--anonymize-uploads Y \
 	--dedupe-uploads Y"
 popd


### PR DESCRIPTION
Upgrade to v2.5.1
[See upstream release page](https://git.pleroma.social/pleroma/pleroma/-/releases/v2.5.1)
Provided description:
## 2.5.1

### Added
- Allow customizing instance languages

### Fixed
- Security: uploading HTTP endpoint can no longer create directories in the upload dir (internal APIs, like backup, still can do it.)
- ~ character in urls in Markdown posts are handled properly
- Exiftool upload filter will now ignore SVG files
- Fix `block_from_stranger` setting
- Fix rel="me"
- Docker images will now run properly
- Fix inproper content being cached in report content
- Notification filter on object content will not operate on the ones that inherently have no content
- ZWNJ and double dots in links are parsed properly for Plain-text posts
- OTP releases will work on systems with a newer libcrypt
- Errors when running Exiftool.ReadDescription filter will not be filled into the image description