### PR TITLE
Remove `demo` dead link (distsn.org)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,6 @@
     "upstream": {
         "license": "AGPL-3.0-only",
         "website": "https://pleroma.social/",
-        "demo": "http://distsn.org/pleroma-instances.html",
         "admindoc": "https://docs.pleroma.social/",
         "code": "https://git.pleroma.social/pleroma/pleroma/"
     },


### PR DESCRIPTION
## Problem

- *The link to Pleroma instances (distsn.org) is dead*

## Solution

- *Remove the link!*

## PR Status

- [x] Code finished and ready to be reviewed/tested
