### PR TITLE
Remove `migrate_to_db` at upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -290,14 +290,6 @@ ynh_script_progression --message="Reloading NGINX web server..." --weight=1
 ynh_systemd_action --service_name=nginx --action=reload
 
 #=================================================
-# POST INSTALL
-#=================================================
-
-# Correct path to 'static dir' in DB
-# This must be done when Pleroma is running (i.e. after install/upgrade and start)
-ynh_exec_warn_less ynh_exec_as $app -s $SHELL -lc "$final_path/live/bin/pleroma_ctl config migrate_to_db"
-
-#=================================================
 # END OF SCRIPT
 #=================================================
 


### PR DESCRIPTION
Executing this at every upgrade erase _all custom config_ of Pleroma made with **Admin FE**

```
ynh_exec_warn_less ynh_exec_as $app -s $SHELL -lc "$final_path/live/bin/pleroma_ctl config migrate_to_db"

```

## Problem

- *All customization of Instance made with Admin FE are lost (reverted to default): alternative frontend, attachement max size, custom logo, etc.*

## Solution

- *Exec `migrate_to_db` only at install and not at upgrade. Note: this partialy revert #224*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
