### PR TITLE
Upgrade to version 2.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post
 **Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
 
 
-**Shipped version:** 2.5.2~ynh1
+**Shipped version:** 2.5.3~ynh1
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post
 **Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
 
 
-**Shipped version:** 2.5.1~ynh2
+**Shipped version:** 2.5.2~ynh1
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -23,7 +23,7 @@ Pour des informations plus détaillées sur Pleroma voir [What is Pleroma](https
 **Interface utilisateur Mastodon pour Pleroma :** Ajouter `/web` à la fin du nom de domaine (URL) de votre installation, par exemple : `https://pleroma.domain.tld/web`
 
 
-**Version incluse :** 2.5.2~ynh1
+**Version incluse :** 2.5.3~ynh1
 
 ## Captures d’écran
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -23,7 +23,7 @@ Pour des informations plus détaillées sur Pleroma voir [What is Pleroma](https
 **Interface utilisateur Mastodon pour Pleroma :** Ajouter `/web` à la fin du nom de domaine (URL) de votre installation, par exemple : `https://pleroma.domain.tld/web`
 
 
-**Version incluse :** 2.5.1~ynh2
+**Version incluse :** 2.5.2~ynh1
 
 ## Captures d’écran
 

--- a/check_process
+++ b/check_process
@@ -16,16 +16,6 @@
 		setup_private=1
 		setup_public=1
 		upgrade=1
-		# 2.2.0~ynh1
-		# upgrade=1	from_commit=059ddc457aabe6962f5960612ed2dc1db53daeeb
-		# 2.2.2~ynh1
-		# upgrade=1	from_commit=63723f18af5b035a41e967078cc3128423b1f9ae
-		# 2.3.0~ynh1
-		# upgrade=1	from_commit=9f5c0970d2bf8bb6111785184b1d3762228b04ec
-		# 2.3.0~ynh2
-		# upgrade=1	from_commit=4757df265b0c3e8d1fc5280190ccfe5705dcb691
-		# 2.3.0~ynh3
-		# upgrade=1	from_commit=28ed2fd7ab7b5e55154991c990d8e780560a56db
 		# 2.4.0~ynh1
 		upgrade=1	from_commit=2c4a57afdc92a6428ccfea3ccb74c7e33dc9b9ff
 		# 2.4.1~ynh1

--- a/check_process
+++ b/check_process
@@ -16,8 +16,6 @@
 		setup_private=1
 		setup_public=1
 		upgrade=1
-		# 2.4.0~ynh1
-		upgrade=1	from_commit=2c4a57afdc92a6428ccfea3ccb74c7e33dc9b9ff
 		# 2.4.1~ynh1
 		upgrade=1	from_commit=e6d9935af254018baf326281662c55407170694d
 		# 2.4.3~ynh1

--- a/conf/amd64.src
+++ b/conf/amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/230112/artifacts/download?file_type=archive
-SOURCE_SUM=98f9dc5410c96892b356d75a48e2aa937e2e35fce99db44317d445280bc8128c
+SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/234433/artifacts/download?file_type=archive
+SOURCE_SUM=8ef0bea62671d39e60f9e08d13109a4c332c552a1f855184063353987d46c84a
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/amd64.src
+++ b/conf/amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/234433/artifacts/download?file_type=archive
-SOURCE_SUM=8ef0bea62671d39e60f9e08d13109a4c332c552a1f855184063353987d46c84a
+SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/238904/artifacts/download?file_type=archive
+SOURCE_SUM=d390b3e21328d51cee185b0f574d5e79adfed6805c15a2686ec764147c6c8019
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/234437/artifacts/download?file_type=archive
-SOURCE_SUM=2e2622a7a50284573fbb3dc66f0510c03d19403ab1e23d6b5dce7bddc11fca95
+SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/238908/artifacts/download?file_type=archive
+SOURCE_SUM=716ab18cbe69c4e82df390a94f91b45681ad53a7410fc46678412a44d96d3b72
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/230116/artifacts/download?file_type=archive
-SOURCE_SUM=05ee20c2a10b8a2393a8aa84fe4f44e86b69fe65321de10cb7a8f6b5c01ac1e4
+SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/234437/artifacts/download?file_type=archive
+SOURCE_SUM=2e2622a7a50284573fbb3dc66f0510c03d19403ab1e23d6b5dce7bddc11fca95
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/armhf.src
+++ b/conf/armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/230231/artifacts/download?file_type=archive
-SOURCE_SUM=bf7caba3ef502e2b21ec8749606a7b207b7c0a67fb767f33e9826fdfb24852c0
+SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/234449/artifacts/download?file_type=archive
+SOURCE_SUM=abab2ad69704b999dbe1b995ce12aabc8069d9620ca332ecc621b20826d6db97
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/armhf.src
+++ b/conf/armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/234449/artifacts/download?file_type=archive
-SOURCE_SUM=abab2ad69704b999dbe1b995ce12aabc8069d9620ca332ecc621b20826d6db97
+SOURCE_URL=https://git.pleroma.social/pleroma/pleroma/-/jobs/238906/artifacts/download?file_type=archive
+SOURCE_SUM=ec7ef8a0dd92325b2e61cd03772a078c28ae72cac4728570e79c73a4ef7c80d4
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -4,7 +4,7 @@ location / {
   proxy_http_version 1.1;
   proxy_set_header Upgrade $http_upgrade;
   proxy_set_header Connection "upgrade";
-  proxy_set_header Host $http_host;
+  proxy_set_header Host $host;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
   proxy_pass http://127.0.0.1:__PORT__;

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Federated social networking server built on open protocols",
         "fr": "Serveur de réseautage social fédéré basé sur des protocoles ouverts"
     },
-    "version": "2.5.2~ynh1",
+    "version": "2.5.3~ynh1",
     "url": "https://pleroma.social/",
     "upstream": {
         "license": "AGPL-3.0-only",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Federated social networking server built on open protocols",
         "fr": "Serveur de réseautage social fédéré basé sur des protocoles ouverts"
     },
-    "version": "2.5.1~ynh2",
+    "version": "2.5.2~ynh1",
     "url": "https://pleroma.social/",
     "upstream": {
         "license": "AGPL-3.0-only",


### PR DESCRIPTION
Upgrade to v2.5.3
[See upstream release page](https://git.pleroma.social/pleroma/pleroma/-/releases/v2.5.3)
Provided description:
### Security
- Emoji pack loader sanitizes pack names
- Reduced permissions of config files and directories, distros requiring greater permissions like group-read need to pre-create the directories