### PR TITLE
Ci auto update 2.8.0 fixed

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -7,5 +7,6 @@
 - [Le o README en galego](README_gl.md)
 - [Baca README dalam bahasa bahasa Indonesia](README_id.md)
 - [Lees de README in het Nederlands](README_nl.md)
+- [Przeczytaj README w języku polski](README_pl.md)
 - [Прочитать README на русский](README_ru.md)
 - [阅读中文（简体）的 README](README_zh_Hans.md)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ It shall NOT be edited by hand.
 
 # Pleroma for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/pleroma.svg)](https://ci-apps.yunohost.org/ci/apps/pleroma/) ![Working status](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)
+[![Integration level](https://apps.yunohost.org/badge/integration/pleroma)](https://ci-apps.yunohost.org/ci/apps/pleroma/)
+![Working status](https://apps.yunohost.org/badge/state/pleroma)
+![Maintenance status](https://apps.yunohost.org/badge/maintained/pleroma)
 
 [![Install Pleroma with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=pleroma)
 
@@ -23,7 +25,7 @@ For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post
 **Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
 
 
-**Shipped version:** 2.6.2~ynh3
+**Shipped version:** 2.8.0~ynh1
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -5,7 +5,9 @@ No se debe editar a mano.
 
 # Pleroma para Yunohost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/pleroma.svg)](https://ci-apps.yunohost.org/ci/apps/pleroma/) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)
+[![Nivel de integración](https://apps.yunohost.org/badge/integration/pleroma)](https://ci-apps.yunohost.org/ci/apps/pleroma/)
+![Estado funcional](https://apps.yunohost.org/badge/state/pleroma)
+![Estado En Mantención](https://apps.yunohost.org/badge/maintained/pleroma)
 
 [![Instalar Pleroma con Yunhost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=pleroma)
 
@@ -23,7 +25,7 @@ For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post
 **Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
 
 
-**Versión actual:** 2.6.2~ynh3
+**Versión actual:** 2.8.0~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -5,7 +5,9 @@ EZ editatu eskuz.
 
 # Pleroma YunoHost-erako
 
-[![Integrazio maila](https://dash.yunohost.org/integration/pleroma.svg)](https://ci-apps.yunohost.org/ci/apps/pleroma/) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)
+[![Integrazio maila](https://apps.yunohost.org/badge/integration/pleroma)](https://ci-apps.yunohost.org/ci/apps/pleroma/)
+![Funtzionamendu egoera](https://apps.yunohost.org/badge/state/pleroma)
+![Mantentze egoera](https://apps.yunohost.org/badge/maintained/pleroma)
 
 [![Instalatu Pleroma YunoHost-ekin](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=pleroma)
 
@@ -23,7 +25,7 @@ For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post
 **Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
 
 
-**Paketatutako bertsioa:** 2.6.2~ynh3
+**Paketatutako bertsioa:** 2.8.0~ynh1
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,7 +5,9 @@ Il NE doit PAS être modifié à la main.
 
 # Pleroma pour YunoHost
 
-[![Niveau d’intégration](https://dash.yunohost.org/integration/pleroma.svg)](https://ci-apps.yunohost.org/ci/apps/pleroma/) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)
+[![Niveau d’intégration](https://apps.yunohost.org/badge/integration/pleroma)](https://ci-apps.yunohost.org/ci/apps/pleroma/)
+![Statut du fonctionnement](https://apps.yunohost.org/badge/state/pleroma)
+![Statut de maintenance](https://apps.yunohost.org/badge/maintained/pleroma)
 
 [![Installer Pleroma avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=pleroma)
 
@@ -23,7 +25,7 @@ Pour des informations plus détaillées sur Pleroma voir [What is Pleroma](https
 **Interface utilisateur Mastodon pour Pleroma :** Ajouter `/web` à la fin du nom de domaine (URL) de votre installation, par exemple : `https://pleroma.domain.tld/web`
 
 
-**Version incluse :** 2.6.2~ynh3
+**Version incluse :** 2.8.0~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -5,7 +5,9 @@ NON debe editarse manualmente.
 
 # Pleroma para YunoHost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/pleroma.svg)](https://ci-apps.yunohost.org/ci/apps/pleroma/) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)
+[![Nivel de integración](https://apps.yunohost.org/badge/integration/pleroma)](https://ci-apps.yunohost.org/ci/apps/pleroma/)
+![Estado de funcionamento](https://apps.yunohost.org/badge/state/pleroma)
+![Estado de mantemento](https://apps.yunohost.org/badge/maintained/pleroma)
 
 [![Instalar Pleroma con YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=pleroma)
 
@@ -23,7 +25,7 @@ For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post
 **Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
 
 
-**Versión proporcionada:** 2.6.2~ynh3
+**Versión proporcionada:** 2.8.0~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -5,7 +5,9 @@ Ini TIDAK boleh diedit dengan tangan.
 
 # Pleroma untuk YunoHost
 
-[![Tingkat integrasi](https://dash.yunohost.org/integration/pleroma.svg)](https://ci-apps.yunohost.org/ci/apps/pleroma/) ![Status kerja](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![Status pemeliharaan](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)
+[![Tingkat integrasi](https://apps.yunohost.org/badge/integration/pleroma)](https://ci-apps.yunohost.org/ci/apps/pleroma/)
+![Status kerja](https://apps.yunohost.org/badge/state/pleroma)
+![Status pemeliharaan](https://apps.yunohost.org/badge/maintained/pleroma)
 
 [![Pasang Pleroma dengan YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=pleroma)
 
@@ -23,7 +25,7 @@ For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post
 **Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
 
 
-**Versi terkirim:** 2.6.2~ynh3
+**Versi terkirim:** 2.8.0~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -5,7 +5,9 @@ Hij mag NIET handmatig aangepast worden.
 
 # Pleroma voor Yunohost
 
-[![Integratieniveau](https://dash.yunohost.org/integration/pleroma.svg)](https://ci-apps.yunohost.org/ci/apps/pleroma/) ![Mate van functioneren](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![Onderhoudsstatus](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)
+[![Integratieniveau](https://apps.yunohost.org/badge/integration/pleroma)](https://ci-apps.yunohost.org/ci/apps/pleroma/)
+![Mate van functioneren](https://apps.yunohost.org/badge/state/pleroma)
+![Onderhoudsstatus](https://apps.yunohost.org/badge/maintained/pleroma)
 
 [![Pleroma met Yunohost installeren](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=pleroma)
 
@@ -23,7 +25,7 @@ For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post
 **Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
 
 
-**Geleverde versie:** 2.6.2~ynh3
+**Geleverde versie:** 2.8.0~ynh1
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -1,0 +1,54 @@
+<!--
+To README zostało automatycznie wygenerowane przez <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+Nie powinno być ono edytowane ręcznie.
+-->
+
+# Pleroma dla YunoHost
+
+[![Poziom integracji](https://apps.yunohost.org/badge/integration/pleroma)](https://ci-apps.yunohost.org/ci/apps/pleroma/)
+![Status działania](https://apps.yunohost.org/badge/state/pleroma)
+![Status utrzymania](https://apps.yunohost.org/badge/maintained/pleroma)
+
+[![Zainstaluj Pleroma z YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=pleroma)
+
+*[Przeczytaj plik README w innym języku.](./ALL_README.md)*
+
+> *Ta aplikacja pozwala na szybką i prostą instalację Pleroma na serwerze YunoHost.*  
+> *Jeżeli nie masz YunoHost zapoznaj się z [poradnikiem](https://yunohost.org/install) instalacji.*
+
+## Przegląd
+
+Pleroma is a microblogging server software that can federate (= exchange messages with) other servers that support ActivityPub. What that means is that you can host a server for yourself or your friends and stay in control of your online identity, but still exchange messages with people on larger servers. Pleroma will federate with all servers that implement ActivityPub, like Friendica, GNU Social, Hubzilla, Mastodon, Misskey, Peertube, and Pixelfed.
+
+For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post/what-is-pleroma/)
+
+**Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
+
+
+**Dostarczona wersja:** 2.8.0~ynh1
+
+## Zrzuty ekranu
+
+![Zrzut ekranu z Pleroma](./doc/screenshots/screenshot1.png)
+
+## Dokumentacja i zasoby
+
+- Oficjalna strona aplikacji: <https://pleroma.social/>
+- Oficjalna dokumentacja dla administratora: <https://docs.pleroma.social/>
+- Repozytorium z kodem źródłowym: <https://git.pleroma.social/pleroma/pleroma/>
+- Sklep YunoHost: <https://apps.yunohost.org/app/pleroma>
+- Zgłaszanie błędów: <https://github.com/YunoHost-Apps/pleroma_ynh/issues>
+
+## Informacje od twórców
+
+Wyślij swój pull request do [gałęzi `testing`](https://github.com/YunoHost-Apps/pleroma_ynh/tree/testing).
+
+Aby wypróbować gałąź `testing` postępuj zgodnie z instrukcjami:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/pleroma_ynh/tree/testing --debug
+lub
+sudo yunohost app upgrade pleroma -u https://github.com/YunoHost-Apps/pleroma_ynh/tree/testing --debug
+```
+
+**Więcej informacji o tworzeniu paczek aplikacji:** <https://yunohost.org/packaging_apps>

--- a/README_ru.md
+++ b/README_ru.md
@@ -5,7 +5,9 @@
 
 # Pleroma для YunoHost
 
-[![Уровень интеграции](https://dash.yunohost.org/integration/pleroma.svg)](https://ci-apps.yunohost.org/ci/apps/pleroma/) ![Состояние работы](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![Состояние сопровождения](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)
+[![Уровень интеграции](https://apps.yunohost.org/badge/integration/pleroma)](https://ci-apps.yunohost.org/ci/apps/pleroma/)
+![Состояние работы](https://apps.yunohost.org/badge/state/pleroma)
+![Состояние сопровождения](https://apps.yunohost.org/badge/maintained/pleroma)
 
 [![Установите Pleroma с YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=pleroma)
 
@@ -23,7 +25,7 @@ For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post
 **Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
 
 
-**Поставляемая версия:** 2.6.2~ynh3
+**Поставляемая версия:** 2.8.0~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -5,7 +5,9 @@
 
 # YunoHost 上的 Pleroma
 
-[![集成程度](https://dash.yunohost.org/integration/pleroma.svg)](https://ci-apps.yunohost.org/ci/apps/pleroma/) ![工作状态](https://ci-apps.yunohost.org/ci/badges/pleroma.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/pleroma.maintain.svg)
+[![集成程度](https://apps.yunohost.org/badge/integration/pleroma)](https://ci-apps.yunohost.org/ci/apps/pleroma/)
+![工作状态](https://apps.yunohost.org/badge/state/pleroma)
+![维护状态](https://apps.yunohost.org/badge/maintained/pleroma)
 
 [![使用 YunoHost 安装 Pleroma](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=pleroma)
 
@@ -23,7 +25,7 @@ For user friendly details about Pleroma: [see here](https://blog.soykaf.com/post
 **Mastodon web front-end for Pleroma:** Add **/web** in front of your Pleroma domain, eg. pleroma.domain.tld/web
 
 
-**分发版本：** 2.6.2~ynh3
+**分发版本：** 2.8.0~ynh1
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Pleroma"
 description.en = "Federated social networking server built on open protocols"
 description.fr = "Serveur de réseautage social fédéré basé sur des protocoles ouverts"
 
-version = "2.6.2~ynh3"
+version = "2.8.0~ynh1"
 
 maintainers = []
 
@@ -71,14 +71,14 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    amd64.url = "https://git.pleroma.social/pleroma/pleroma/-/jobs/256761/artifacts/download"
-    amd64.sha256 = "4408be4d30c669a58589f3f0e5754c4f17f6a99d012c801204aacdcda4f1c9ef"
+    amd64.url = "https://git.pleroma.social/pleroma/pleroma/-/archive/v2.8.0/pleroma-v2.8.0.tar.gz"
+    amd64.sha256 = "f5144af64ce822310b9943df274bac3c1c7704e16750ee247f55b4fc7fe5be67"
 
-    armhf.url = "https://git.pleroma.social/pleroma/pleroma/-/jobs/256788/artifacts/download"
-    armhf.sha256 = "ceff4df89f53654cfac3aafb685d0df2977a3073133ca7a472e92ebb349a58f1"
+    armhf.url = "https://git.pleroma.social/pleroma/pleroma/-/archive/v2.8.0/pleroma-v2.8.0.tar.gz"
+    armhf.sha256 = "f5144af64ce822310b9943df274bac3c1c7704e16750ee247f55b4fc7fe5be67"
 
-    arm64.url = "https://git.pleroma.social/pleroma/pleroma/-/jobs/256765/artifacts/download"
-    arm64.sha256 = "eb38fddc449a0b47191d284671af3f1fe229b4d31b420cb8478f615006bd8757"
+    arm64.url = "https://git.pleroma.social/pleroma/pleroma/-/archive/v2.8.0/pleroma-v2.8.0.tar.gz"
+    arm64.sha256 = "f5144af64ce822310b9943df274bac3c1c7704e16750ee247f55b4fc7fe5be67"
 
     format = "zip"
     extract = true

--- a/manifest.toml
+++ b/manifest.toml
@@ -80,7 +80,7 @@ ram.runtime = "50M"
     arm64.url = "https://git.pleroma.social/pleroma/pleroma/-/archive/v2.8.0/pleroma-v2.8.0.tar.gz"
     arm64.sha256 = "f5144af64ce822310b9943df274bac3c1c7704e16750ee247f55b4fc7fe5be67"
 
-    format = "zip"
+    format = "tar.gz"
     extract = true
 
     # Those assets are to make autoupdate work, but are dummy artifacts, because


### PR DESCRIPTION
## Problem

CI auto update (#280) updated sources from upstream job's output to releases, but didn't update the type (the archive is a `tar.gz`)

## Solution

Replace with `zip`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
