### PR TITLE
2.10.0 arm64 and amd64 upstream otp_en  #290

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Pleroma"
 description.en = "Federated social networking server built on open protocols"
 description.fr = "Serveur de réseautage social fédéré basé sur des protocoles ouverts"
 
-version = "2.8.0~ynh2"
+version = "2.10.0~ynh1"
 
 maintainers = []
 
@@ -21,7 +21,7 @@ fund = "https://liberapay.com/Pleroma-euro/"
 
 [integration]
 yunohost = ">= 12.0.0"
-architectures = ["amd64", "armhf", "arm64"]
+architectures = ["amd64", "arm64"]
 multi_instance = false
 
 ldap = true
@@ -74,14 +74,11 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    amd64.url = "https://git.pleroma.social/pleroma/pleroma/-/jobs/283011/artifacts/download"
-    amd64.sha256 = "31440d91e7448cd3912144638ea7c59300d45c2fecfad24f0cf9c8ea91058ce0"
+    arm64.url = "https://git.pleroma.social/api/v4/projects/2/jobs/artifacts/stable/download?job=arm64"
+    arm64.sha256 = "a49b7e4fcfca00fea97fcedad94b4caa230c57b9eefc2f0a5208294c4a4ca1cd"
 
-    armhf.url = "https://git.pleroma.social/pleroma/pleroma/-/jobs/282573/artifacts/download"
-    armhf.sha256 = "fdb6e7103a1de055102c30158f1153be468d424a1c9b713dd2571deb2aa20f4f"
-
-    arm64.url = "https://git.pleroma.social/pleroma/pleroma/-/jobs/283015/artifacts/download"
-    arm64.sha256 = "ffb9f5c56531076ca14bb23c25d7e78547fb4ef37c7eafd81740bfde966358a8"
+    amd64.url = "https://git.pleroma.social/api/v4/projects/2/jobs/artifacts/stable/download?job=amd64"
+    amd64.sha256 = "20291fedca2d178dbe910fa9daeaee2aa1c9214ed7e33bf587edc70c383ccb5e"
 
     format = "zip"
     extract = true


### PR DESCRIPTION
tentatively fix 404 error upgrade/install

WARNING no more armhf arm 32bit

## Problem

- url given in manifest to obtain pleroma source was temporary and is gone

## Solution

- use documented url from pleroma upstream projet otp packaging and provide sha256 related to 2.10.0 version

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
