### PR TITLE
2.8.0 bookworm Yunohost-Apps/pleroma-otp reference

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -21,7 +21,7 @@ fund = "https://liberapay.com/Pleroma-euro/"
 
 [integration]
 yunohost = ">= 12.0.0"
-architectures = ["amd64", "armhf", "arm64"]
+architectures = ["amd64", "arm64"]
 multi_instance = false
 
 ldap = true
@@ -74,13 +74,10 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    amd64.url = "https://github.com/Thovi98/pleroma-otp/releases/download/v2.8.0/pleroma-v2.8.0-bookworm-amd64.tar.gz"
+    amd64.url = "https://github.com/Yunohost-Apps/pleroma-otp/releases/download/v2.8.0/pleroma-v2.8.0-bookworm-amd64.tar.gz"
     amd64.sha256 = "e6aa2edbef2cef3b1f60b9a74d39a7aeb87512640db5c6744ce3ea80872336be"
-
-    armhf.url = "https://git.pleroma.social/pleroma/pleroma/-/jobs/282573/artifacts/download"
-    armhf.sha256 = "fdb6e7103a1de055102c30158f1153be468d424a1c9b713dd2571deb2aa20f4f"
     
-    arm64.url = "https://github.com/Thovi98/pleroma-otp/releases/download/v2.8.0/pleroma-v2.8.0-bookworm-arm64.tar.gz"
+    arm64.url = "https://github.com/Yunohost-Apps/pleroma-otp/releases/download/v2.8.0/pleroma-v2.8.0-bookworm-arm64.tar.gz"
     arm64.sha256 = "7daa2a728fea97f94149fa672ba668150beb3a1cf2822b6cbc7ef3dc782e707f"
 
     extract = true

--- a/tests.toml
+++ b/tests.toml
@@ -16,5 +16,4 @@ test_format = 1.0
     # Commits to test upgrade from
     # -------------------------------
 
-    test_upgrade_from.196d35387131bb7fe193c361e1405e21ac36ceaf.name = "Upgrade from 2.8.0~ynh1"
-    #test_upgrade_from.ba16bc8bee7715c479a7ee575ec5f7d9970a84f8.name = "2.4.3"
+    # This is a reference there is actualy no older installable package to upgrade from due to upstream change.


### PR DESCRIPTION
This is a reference
There is actualy no older installable package to upgrade from due to upstream change.

## Problem

- previous otp branch rely on a repository now moved to Yunohost-Apps
- an upgrade test commit was set while there is no working package to upgrade from since upsteam don't maintain it.
- upstream armh is not existing nor built in new repository

## Solution

- set right project, remove upgrade test and armh support

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
