### PR TITLE
document instance name must not contain spaces #270

### DIFF
--- a/doc/PRE_INSTALL.md
+++ b/doc/PRE_INSTALL.md
@@ -4,3 +4,4 @@
 - Pleroma requires a valid **certificate** installed on the domain.
 - This package is currently set to **single-instance** that means you can run a **single Pleroma instance** on a **single server**.
 - The admin **password** entered when installing must **not** contain **special characters**. (See [issue #132](https://github.com/YunoHost-Apps/pleroma_ynh/issues/132))
+- The instance name must **not** contain **spaces**. (See [issue #270](https://github.com/YunoHost-Apps/pleroma_ynh/issues/270))

--- a/doc/PRE_INSTALL_fr.md
+++ b/doc/PRE_INSTALL_fr.md
@@ -4,3 +4,4 @@
 - Pleroma nécessite par ailleurs un **certificat SSL** valide activé sur ce domaine.
 - Ce paquet est actuellement configuré pour une **instance unique**, c’est-à-dire que l’on ne peut installer _qu’une seule instance_ de Pleroma sur un même serveur Yunohost.
 - Le **mot de passe** saisi durant l’installation ne doit _en aucun cas_ contenir de **caractères spéciaux**. (Voir [issue #132](https://github.com/YunoHost-Apps/pleroma_ynh/issues/132))
+- Le nom de l'instance ne doit **pas** contenir d'**espaces** (Voir [issue #270](https://github.com/YunoHost-Apps/pleroma_ynh/issues/270))


### PR DESCRIPTION
## Problem

- Install fails when instance name contains spaces see bug #270
 
## Solution

- Document this in pre install to warn user about this limitation