### PR TITLE
pleroma service requires write access to libraries #302

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -29,6 +29,9 @@ ynh_script_progression "Setting up source files..."
 
 ynh_setup_source --dest_dir="$install_dir/live"
 
+# pleroma service requires to have write access to libraries ( ex #302 )
+chown -R "$app:$app" "$install_dir/live"
+
 #=================================================
 # UPDATE THE POSTGRESQL DATABASE
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -94,6 +94,9 @@ ynh_script_progression "Upgrading source files..."
 
 ynh_setup_source --dest_dir="$install_dir/live" --full_replace
 
+# pleroma service requires to have write access to libraries ( ex #302 )
+chown -R "$app:$app" "$install_dir/live"
+
 #=================================================
 # REAPPLY SYSTEM CONFIGURATIONS
 #=================================================


### PR DESCRIPTION
yunohost standard set root:root to binaries on /var/www/pleroma/live during ynh_setup_source pleroma requires to have pleroma write access for library upgrade add a comment in code to emphasis this when code cleaning is done without full context use same owership at install and upgrade ( please note : no www-data )

## Problem

- Fix proposal for #302

## Solution

- give pleroma owenership on /var/www/pleroma/live 

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)


