### PR TITLE
Don't call apt-key if not needed or not provided

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -36,8 +36,14 @@ if yunohost firewall list | grep -q "\- $port$"; then
 fi
 
 # Remove old repository
-ynh_safe_rm "/etc/apt/sources.list.d/erlang-solutions.list"
-apt-key del A14F4FCA
+if [[ -f "/etc/apt/sources.list.d/erlang-solutions.list" ]]
+then
+    ynh_safe_rm "/etc/apt/sources.list.d/erlang-solutions.list"
+    if which apt-key
+    then
+	apt-key del A14F4FCA
+    fi
+fi
 
 # Switch to $install_dir/live
 if [ ! -d "$install_dir/live" ]; then


### PR DESCRIPTION
at upgrade removal of old repository is now done with protection if erlang-solutions.list is not existing there is no need to remove it if apt-key script/binary is not provided don't call it.

this removal is anyway for very old installations prior otp version so before 2020

## Problem

- Fix for #304

## Solution

- Don't call apt-key if not provided

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)
