### PR TITLE
Don't use SSOWat, no header passing #301

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Pleroma"
 description.en = "Federated social networking server built on open protocols"
 description.fr = "Serveur de réseautage social fédéré basé sur des protocoles ouverts"
 
-version = "2.10.2~ynh1"
+version = "2.10.2~ynh2"
 
 maintainers = []
 
@@ -92,6 +92,7 @@ ram.runtime = "50M"
 
     [resources.permissions]
     main.url = "/"
+    main.auth_header = false
 
     [resources.ports]
     main.default = 8095


### PR DESCRIPTION
main.auth_header = false

## Problem

- It is not possible to log in pleroma when connected to portal

## Solution

- set main.auth_header = false

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)
